### PR TITLE
Fixes Github issue #84

### DIFF
--- a/count/count_classes.go
+++ b/count/count_classes.go
@@ -56,6 +56,13 @@ func JarClasses(path string) (int, error) {
 			return nil
 		}
 
+		// Check for zero byte JAR files with name containing 'none' - these can not be unzipped
+		// examples of these were found in the JDK, e.g. svm-none.jar
+		// See https://github.com/paketo-buildpacks/libjvm/issues/84
+		if info.Size() == 0 && strings.Contains(info.Name(), "none") {
+			return nil
+		}
+
 		z, err := zip.OpenReader(path)
 		if err != nil {
 			return fmt.Errorf("unable to open ZIP %s\n%w", path, err)

--- a/count/count_classes_test.go
+++ b/count/count_classes_test.go
@@ -57,4 +57,17 @@ func testCountClasses(t *testing.T, context spec.G, it spec.S) {
 	it("counts files in archives", func() {
 		Expect(count.Classes("testdata")).To(Equal(2))
 	})
+
+	it("skips empty zip/jar files with none in the name", func() {
+		Expect(ioutil.WriteFile(filepath.Join(path, "test-none.jar"), []byte{}, 0644)).To(Succeed())
+
+		Expect(count.Classes(path)).To(Equal(0))
+	})
+
+	it("fails for empty zip/jar files without none in the name", func() {
+		Expect(ioutil.WriteFile(filepath.Join(path, "test.jar"), []byte{}, 0644)).To(Succeed())
+
+		_, err := count.Classes(path)
+		Expect(err).To(MatchError(ContainSubstring("zip: not a valid zip file")))
+	})
 }


### PR DESCRIPTION
GraalVM JDK contains some 0-byte JAR files named '*none*' which could not be unzipped during class counting - for example, 'svm-none.jar'. This caused builds with the GraalVM buildpack to fail.

This change checks for 0-byte JAR file with name containing 'none' and does not attempt to unzip & count classes for such files.

Fixes paketo-buildpacks/libjvm#84